### PR TITLE
combine_results.py pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# iJump -test
+# iJump
 
 <img src="./img/logo/logo1.png" width="100" height="120">
 
 Software for search of Insertion Sequences (IS) rearrangements in evolved population sequencing data.
 *Program is in a development stage, and I will appreciate any feedback.*
-Ss
+
 **iJump** searches for IS elements rearrangements in evolved populations of single organism and estimates what fraction of a population is affected by the rearrangement. iJump uses soft-clipped reads to find evidense for rearrangements. 
 
 **NOTE:** Working with short-read-only assembled genomes is difficult with iJump. The reason is that usually IS elements are repetitive regions which are difficult to resolve for assemblers. This often result in shreading IS elements to several/many sometimes overlapped short contigs. This introduces difficulty either for boundaries determination and for mapping algorithms.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# iJump
+# iJump -test
 
 <img src="./img/logo/logo1.png" width="100" height="120">
 
 Software for search of Insertion Sequences (IS) rearrangements in evolved population sequencing data.
 *Program is in a development stage, and I will appreciate any feedback.*
-
+Ss
 **iJump** searches for IS elements rearrangements in evolved populations of single organism and estimates what fraction of a population is affected by the rearrangement. iJump uses soft-clipped reads to find evidense for rearrangements. 
 
 **NOTE:** Working with short-read-only assembled genomes is difficult with iJump. The reason is that usually IS elements are repetitive regions which are difficult to resolve for assemblers. This often result in shreading IS elements to several/many sometimes overlapped short contigs. This introduces difficulty either for boundaries determination and for mapping algorithms.

--- a/combine_results.py
+++ b/combine_results.py
@@ -129,7 +129,7 @@ def make_dense_table(summary_table):
                     summary_table_result.loc[row[0], 'Stop'] = stop_junctions[start_junctions.index(row[1])]
         elif row[1] == 0 and row[2] > 0:
             if row[2] in stop_junctions:
-                junct_index = start_junctions.index(row[2])
+                junct_index = stop_junctions.index(row[2])
                 if chrom_of_junction[junct_index] == row[3] and is_names_junctions[junct_index] == row[4]:
                     summary_table_result.loc[row[0], 'Start'] = start_junctions[stop_junctions.index(row[2])]
         else:

--- a/combine_results.py
+++ b/combine_results.py
@@ -128,7 +128,7 @@ def make_dense_table(summary_table):
                 if chrom_of_junction[junct_index] == row[3] and is_names_junctions[junct_index] == row[4]:
                     summary_table_result.loc[row[0], 'Stop'] = stop_junctions[start_junctions.index(row[1])]
         elif row[1] == 0 and row[2] > 0:
-            if row[2] in start_junctions:
+            if row[2] in stop_junctions:
                 junct_index = start_junctions.index(row[2])
                 if chrom_of_junction[junct_index] == row[3] and is_names_junctions[junct_index] == row[4]:
                     summary_table_result.loc[row[0], 'Start'] = start_junctions[stop_junctions.index(row[2])]


### PR DESCRIPTION
Changed 'start' to 'stop' in 2 instances (lines 131 & 132) for make_dense_table function. Looks like this should fix issue with running precise mode. Currently the 'stop_junctions' are being compared against a list of start junctions from what I can deduce. Definitely this block causing issues, as running in 'average' mode does not raise the same error